### PR TITLE
Add FK GridInfo.dataCollectionId

### DIFF
--- a/schema/updates/2020_10_22_GridInfo_dcId.sql
+++ b/schema/updates/2020_10_22_GridInfo_dcId.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_10_22_GridInfo_dcId.sql', 'ONGOING');
+
+ALTER TABLE GridInfo
+  ADD dataCollectionId int(11) unsigned, 
+  ADD CONSTRAINT `GridInfo_fk_dataCollectionId`
+    FOREIGN KEY (`dataCollectionId`)
+      REFERENCES `DataCollection` (`dataCollectionId`)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_10_22_GridInfo_dcId.sql';


### PR DESCRIPTION
As per agreement in [modeling issue 35](https://github.com/ispyb/ispyb-database-modeling/issues/35), GridInfo should link to DataCollection instead of DataCollectionGroup.

Note that:
-  this does not remove the existing FK to DataCollectionGroup.
- The following stored procedures may need updating before this can be used: `retrieve_grid_info_for_dcg`, `retrieve_grid_info_for_dcg_v2`, `retrieve_grid_info_for_dc_ids`, `upsert_dcg_grid`.