### PR TITLE
Add new columns to ContainerQueueSample and DataCollection

### DIFF
--- a/schema/updates/2020_11_19_ContainerQueueSample.sql
+++ b/schema/updates/2020_11_19_ContainerQueueSample.sql
@@ -1,0 +1,15 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_11_19_ContainerQueueSample.sql', 'ONGOING');
+
+ALTER TABLE `ContainerQueueSample` 
+  ADD `dataCollectionPlanId` INT UNSIGNED NULL DEFAULT NULL,
+  ADD CONSTRAINT `ContainerQueueSample_dataCollectionPlanId`
+    FOREIGN KEY (`dataCollectionPlanId`)
+      REFERENCES `DiffractionPlan`(`diffractionPlanId`)
+        ON DELETE NO ACTION ON UPDATE NO ACTION,
+  ADD `blSampleId` INT(10) UNSIGNED NULL DEFAULT NULL,
+  ADD CONSTRAINT `ContainerQueueSample_blSampleId`
+    FOREIGN KEY (`blSampleId`)
+      REFERENCES `BLSample`(`blSampleId`)
+        ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_11_19_ContainerQueueSample.sql';

--- a/schema/updates/2020_11_19_DataCollection.sql
+++ b/schema/updates/2020_11_19_DataCollection.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_11_19_DataCollection.sql', 'ONGOING');
+
+ALTER TABLE `DataCollection`
+  ADD `dataCollectionPlanId` INT UNSIGNED NULL DEFAULT NULL,
+  ADD CONSTRAINT `DataCollection_ibfk9`
+    FOREIGN KEY (`dataCollectionPlanId`)
+      REFERENCES `DiffractionPlan`(`diffractionPlanId`)
+        ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_11_19_DataCollection.sql';

--- a/schema/updates/2020_11_19_DataCollection.sql
+++ b/schema/updates/2020_11_19_DataCollection.sql
@@ -2,7 +2,7 @@ INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_11_19_D
 
 ALTER TABLE `DataCollection`
   ADD `dataCollectionPlanId` INT UNSIGNED NULL DEFAULT NULL,
-  ADD CONSTRAINT `DataCollection_ibfk9`
+  ADD CONSTRAINT `DataCollection_dataCollectionPlanId`
     FOREIGN KEY (`dataCollectionPlanId`)
       REFERENCES `DiffractionPlan`(`diffractionPlanId`)
         ON DELETE NO ACTION ON UPDATE NO ACTION;


### PR DESCRIPTION
- New column to allowing queuing of samples as the ContainerQueueSample table currently only supports subsamples
- New column to link a ContainerQueueSample to DataCollectionPlan to give us the queued collection parameters for the sample
- New column to link DataCollection to DataCollectionPlan so we see the requested params for a data collection

This is based on Stu's proposal in the ispyb-modeling repo:
https://github.com/ispyb/ispyb-database-modeling/issues/52