### PR TITLE
New key-value table to hold data collection plan params

### DIFF
--- a/schema/updates/2020_11_19_DataCollectionPlanParameter.sql
+++ b/schema/updates/2020_11_19_DataCollectionPlanParameter.sql
@@ -1,0 +1,12 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_11_19_DataCollectionPlanParameter.sql', 'ONGOING');
+
+CREATE TABLE `DataCollectionPlanParameter` (
+  `dataCollectionPlanParameterId` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `dataCollectionPlanId` int(11) unsigned DEFAULT NULL,
+  `parameterKey` varchar(80) DEFAULT NULL COMMENT 'E.g. qMin, qMax, ...',
+  `parameterValue` varchar(1024) DEFAULT NULL,
+  PRIMARY KEY (`dataCollectionPlanParameterId`),
+  CONSTRAINT `DataCollectionPlanParameter_dataCollectionPlanId` FOREIGN KEY (`dataCollectionPlanId`) REFERENCES `DiffractionPlan` (`diffractionPlanId`)
+);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_11_19_DataCollectionPlanParameter.sql';


### PR DESCRIPTION
As discussed in the comments for internal Jira ticket I03-463, a new key-value table to hold data collection plan parameters seems to make sense. 

We seem to add more and more columns to the `DiffractionPlan` table to hold these parameters, but that doesn't really seem like a "scalable" solution in the longer term. As more instruments are integrated with ISPyB, it seems likely that more and more columns would be needed for the `DiffractionPlan` table. While I think technically speaking this should be OK, I think in practice that a key-value approach is more practical and flexible for the data writers as new parameters won't require a schema change. 

I was thinking that perhaps we could have a shared key-value table for both data collection **and** processing parameters, but for performance reasons it's probably better to have two different tables.  