### PR TITLE
Allow autoprocprogramid to be nullable in imagequalityindicators

### DIFF
--- a/schema/updates/20200731_autoprocprogram_nullable_iqi.sql
+++ b/schema/updates/20200731_autoprocprogram_nullable_iqi.sql
@@ -1,0 +1,6 @@
+INSERT INTO SchemaStatus (scriptName, schemaStatus) VALUES ('20200731_autoprocprogram_nullable_iqi.sql', 'ONGOING');
+
+ALTER TABLE `ImageQualityIndicators`
+	CHANGE `autoProcProgramId` `autoProcProgramId` INT(10) UNSIGNED NULL COMMENT 'Foreign key to the AutoProcProgram table';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' where scriptName = '20200731_autoprocprogram_nullable_iqi.sql';


### PR DESCRIPTION
There are some cases where imagequalityindicators can be calculated on the fly and do not require launching an external program. Hence allow this to be nullable