### PR TITLE
Add missing Container.experimentTypeId FK

### DIFF
--- a/schema/updates/2020_12_04_Container_experimentTypeId_FK.sql
+++ b/schema/updates/2020_12_04_Container_experimentTypeId_FK.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus)
+  VALUES ('2020_12_04_Container_experimentTypeId_FK.sql', 'ONGOING');
+
+ALTER TABLE Container
+  ADD experimentTypeId int unsigned,
+  ADD CONSTRAINT `Container_fk_experimentTypeId` FOREIGN KEY (`experimentTypeId`)
+    REFERENCES `ExperimentType` (`experimentTypeId`);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' 
+  WHERE scriptName = '2020_12_04_Container_experimentTypeId_FK.sql';


### PR DESCRIPTION
When we created the `ExperimentType` table previously we forgot to add an `experimentTypeId` foreign key in the `Container` table. This PR adds this missing foreign key.