### PR TITLE
Old prod tables previously not added to the repo schema

### DIFF
--- a/schemas/ispyb/updates/2021_03_03_BF_automationError.sql
+++ b/schemas/ispyb/updates/2021_03_03_BF_automationError.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_03_03_BF_automationError.sql', 'ONGOING');
+
+CREATE TABLE `BF_automationError` (
+  `automationErrorId` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `errorType` varchar(40) NOT NULL,
+  `solution` text DEFAULT NULL,
+  PRIMARY KEY (`automationErrorId`)
+);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_03_03_BF_automationError.sql';

--- a/schemas/ispyb/updates/2021_03_03_BF_automationFault.sql
+++ b/schemas/ispyb/updates/2021_03_03_BF_automationFault.sql
@@ -1,0 +1,18 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_03_03_BF_automationFault.sql', 'ONGOING');
+
+CREATE TABLE `BF_automationFault` (
+  `automationFaultId` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `automationErrorId` int(10) unsigned DEFAULT NULL,
+  `containerId` int(10) unsigned DEFAULT NULL,
+  `severity` enum('1','2','3') DEFAULT NULL,
+  `stacktrace` text DEFAULT NULL,
+  `resolved` tinyint(1) DEFAULT NULL,
+  `faultTimeStamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`automationFaultId`),
+  KEY `BF_automationFault_ibfk1` (`automationErrorId`),
+  KEY `BF_automationFault_ibfk2` (`containerId`),
+  CONSTRAINT `BF_automationFault_ibfk1` FOREIGN KEY (`automationErrorId`) REFERENCES `BF_automationError` (`automationErrorId`),
+  CONSTRAINT `BF_automationFault_ibfk2` FOREIGN KEY (`containerId`) REFERENCES `Container` (`containerId`)
+);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_03_03_BF_automationFault.sql';


### PR DESCRIPTION
Two tables:

- BF_automationError: This is a lookup table with different errorTypes and a text column for the solution. 
- BF_automationFault: This table can optionally reference a Container and a BF_automationError, and has a severity enum, a column for the stacktrace and more.

