### PR TITLE
Modify retrieve_scm_container* sprocs t

### DIFF
--- a/schemas/ispyb/stored_programs/sp_retrieve_scm_container.sql
+++ b/schemas/ispyb/stored_programs/sp_retrieve_scm_container.sql
@@ -26,7 +26,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -46,6 +46,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.containerId = p_id AND per.login = p_authLogin;
@@ -59,7 +60,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -76,6 +77,7 @@ BEGIN
           FROM Container c
             JOIN BLSession bs ON bs.sessionId = c.sessionId
             JOIN Proposal p ON p.proposalId = bs.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.containerId = p_id;
@@ -95,7 +97,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -116,6 +118,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.containerId = p_id AND per.login = p_authLogin;
@@ -129,7 +132,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -147,6 +150,7 @@ BEGIN
             JOIN Dewar d ON c.dewarId = d.dewarId
             JOIN Shipping s ON s.shippingId = d.shippingId
             JOIN Proposal p ON p.proposalId = s.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.containerId = p_id;

--- a/schemas/ispyb/stored_programs/sp_retrieve_scm_container_for_barcode.sql
+++ b/schemas/ispyb/stored_programs/sp_retrieve_scm_container_for_barcode.sql
@@ -28,7 +28,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -48,6 +48,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.barcode = p_barcode AND per.login = p_authLogin;
@@ -61,7 +62,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -78,6 +79,7 @@ BEGIN
           FROM Container c
             JOIN BLSession bs ON bs.sessionId = c.sessionId
             JOIN Proposal p ON p.proposalId = bs.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.barcode = p_barcode;
@@ -96,7 +98,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -117,6 +119,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.barcode = p_barcode AND per.login = p_authLogin;
@@ -130,7 +133,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -148,6 +151,7 @@ BEGIN
             JOIN Dewar d ON c.dewarId = d.dewarId
             JOIN Shipping s ON s.shippingId = d.shippingId
             JOIN Proposal p ON p.proposalId = s.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE c.barcode = p_barcode;

--- a/schemas/ispyb/stored_programs/sp_retrieve_scm_containers_for_session.sql
+++ b/schemas/ispyb/stored_programs/sp_retrieve_scm_containers_for_session.sql
@@ -32,7 +32,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -52,6 +52,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE p.proposalCode = p_proposalCode AND p.proposalNumber = p_proposalNumber AND bs.visit_number = p_sessionNumber AND c.containerStatus = p_status AND per.login = p_authLogin;
@@ -65,7 +66,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -82,6 +83,7 @@ BEGIN
           FROM Container c
             JOIN BLSession bs ON bs.sessionId = c.sessionId
             JOIN Proposal p ON p.proposalId = bs.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE p.proposalCode = p_proposalCode AND p.proposalNumber = p_proposalNumber AND bs.visit_number = p_sessionNumber AND c.containerStatus = p_status;
@@ -101,7 +103,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -122,6 +124,7 @@ BEGIN
             JOIN BLSession bs2 ON bs2.proposalId = p.proposalId
             JOIN Session_has_Person shp ON shp.sessionId = bs2.sessionId
             JOIN Person per on per.personId = shp.personId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE p.proposalCode = p_proposalCode AND p.proposalNumber = p_proposalNumber AND c.containerStatus = p_status AND per.login = p_authLogin;
@@ -135,7 +138,7 @@ BEGIN
             c.ownerId "ownerId",
             per2.login "ownerUsername",
             c.code "name",
-            (SELECT ct.name FROM ContainerType ct WHERE c.containerTypeId = ct.containerTypeId) "type",
+            IFNULL(ct.name, c.containerType) "type",
             c.barcode "barcode",
             c.beamlineLocation "beamline",
             c.sampleChangerLocation "location",
@@ -153,6 +156,7 @@ BEGIN
             JOIN Dewar d ON c.dewarId = d.dewarId
             JOIN Shipping s ON s.shippingId = d.shippingId
             JOIN Proposal p ON p.proposalId = s.proposalId
+            LEFT JOIN ContainerType ct ON ct.containerTypeId = c.containerTypeId
             LEFT JOIN Person per2 ON per2.personId = c.ownerId
             LEFT JOIN ExperimentType et ON et.experimentTypeId = c.experimentTypeId
           WHERE p.proposalCode = p_proposalCode AND p.proposalNumber = p_proposalNumber AND c.containerStatus = p_status;


### PR DESCRIPTION
Preferentially use the `ContainerType` table for container type name and capacity, but if they're `NULL` then fall back to the columns in `Container`.