### PR TITLE
Add additional container types: some historical, some new

### DIFF
--- a/schemas/ispyb/updates/2021_04_01_ContainerType_insert.sql
+++ b/schemas/ispyb/updates/2021_04_01_ContainerType_insert.sql
@@ -1,0 +1,13 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_04_01_ContainerType_insert.sql', 'ONGOING');
+
+INSERT INTO ContainerType (containerTypeId, name, capacity, proposalType, active) 
+  VALUES 
+    (27, 'Basket', NULL, 'mx', 0),   -- capacity varies, used by i24 most recently in 2016
+    (28, 'Cane', NULL, 'mx', 0),     -- capacity varies, assumed mx, used most recently in 2013
+    (29, 'Terasaki72', 72, 'mx', 0), -- used by i24 most recently in 2017
+    (30, 'Puck-16', 16, 'mx', 1),    -- used by i24 most recently in 2020
+    (31, 'Block-4', 16, 'mx', 1),    -- used by i23 most recently in 2021, all have capacity 16
+    (32, 'Box', 25, 'xpdf', 1), 
+    (33, 'Puck', 22, 'xpdf', 1);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_04_01_ContainerType_insert.sql';


### PR DESCRIPTION
- Basket, capacity varies, proposalType: mx, deactivated   -- used by i24 most recently in 2016
- Cane, capacity varies, proposalType: mx, deactivated     -- assumed mx, used most recently in 2013
- Terasaki72, capacity: 72, proposalType: mx, deactivated -- used by i24 most recently in 2017
- Puck-16, capacity: 16, proposalType: mx, active              -- used by i24 most recently in 2020
- Block-4', capacity: 16, proposalType: mx, active              -- used by i23 most recently in 2021
- Box, capacity: 25, proposalType: xpdf, active
- Puck, capacity: 22, proposalType: xpdf, active