### PR TITLE
Proposed new stored procedures for cryoEM

### DIFF
--- a/schemas/ispyb/stored_programs/sp_insert_cryoem_initial_model.sql
+++ b/schemas/ispyb/stored_programs/sp_insert_cryoem_initial_model.sql
@@ -1,0 +1,51 @@
+-- Example calls:
+--
+-- First create a Movie, a MotionCorrection, a ParticlePicker, a ParticleClassificationGroup and a ParticleClassification:
+--
+-- SET @mid := NULL;
+-- SET @mcid := NULL;
+-- CALL upsert_movie(@mid, 6017405, NULL, NULL, NULL, NULL, NULL, NULL);
+-- CALL upsert_motion_correction(@mcid, @mid, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+-- SET @ppid := NULL;
+-- CALL upsert_particle_picker(@ppid, @mcid, NULL, 'pp template 1', 8.1, 151);
+-- SET @pcgid := NULL;
+-- CALL upsert_particle_classification_group(@pcgid, @ppid, NULL, '2D', 1, 1300, 2, 'P222');
+-- SET @pcid := NULL;
+-- CALL upsert_particle_classification(@pcid, @pcgid, 1, '/absolute/path/to/image/file', 1200, 2, 3.5, 2.8, 92);
+--
+-- Then call this procedure:
+-- SET @cimid := NULL;
+-- CALL insert_cryoem_initial_model(@cimid, @pcid, 2.9, 326);
+
+DELIMITER ;;
+CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `insert_cryoem_initial_model`(
+  OUT p_id int unsigned,
+  p_particleClassificationId int unsigned,
+  p_resolution float,
+  p_numberOfParticles int unsigned
+ )
+  MODIFIES SQL DATA
+  COMMENT 'Inserts or updates info about a (cryoEM) initial model for a given particle classification (p_particleClassificationId).\nMandatory columns: p_particleClassificationId\nReturns: Record ID in p_id.'
+BEGIN
+  IF p_particleClassificationId IS NOT NULL THEN
+    START TRANSACTION;
+
+    INSERT INTO CryoemInitialModel (resolution, numberOfParticles)
+      VALUES (p_resolution, p_numberOfParticles);
+
+    SET p_id = LAST_INSERT_ID();
+
+    INSERT INTO ParticleClassification_has_CryoemInitialModel (
+      particleClassificationId, cryoemInitialModelId
+    ) 
+    VALUES (
+      p_particleClassificationId, p_id
+    );
+
+    COMMIT;
+
+  ELSE
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument is NULL: particleClassificationId must be non-NULL.';
+  END IF;
+END;;
+DELIMITER ;

--- a/schemas/ispyb/stored_programs/sp_upsert_particle_classification.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_particle_classification.sql
@@ -22,7 +22,7 @@ CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_particle_classifica
   p_classNumber int unsigned,
   p_classImageFullPath varchar(255),
   p_particlesPerClass int unsigned,
-  p_rotationAccuracy int unsigned,
+  p_rotationAccuracy float,
   p_translationAccuracy float,
   p_estimatedResolution float,
   p_overallFourierCompleteness float

--- a/schemas/ispyb/stored_programs/sp_upsert_particle_classification.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_particle_classification.sql
@@ -1,0 +1,59 @@
+-- Example calls:
+--
+-- First create a Movie, a MotionCorrection, a ParticlePicker and a ParticleClassificationGroup:
+--
+-- SET @mid := NULL;
+-- SET @mcid := NULL;
+-- CALL upsert_movie(@mid, 6017405, NULL, NULL, NULL, NULL, NULL, NULL);
+-- CALL upsert_motion_correction(@mcid, @mid, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+-- SET @ppid := NULL;
+-- CALL upsert_particle_picker(@ppid, @mcid, NULL, 'pp template 1', 8.1, 151);
+-- SET @pcgid := NULL;
+-- CALL upsert_particle_classification_group(@pcgid, @ppid, NULL, '2D', 1, 1300, 2, 'P222');
+
+-- Then call this procedure:
+-- SET @pcid := NULL;
+-- CALL upsert_particle_classification(@pcid, @pcgid, 1, '/absolute/path/to/image/file', 1200, 2, 3.5, 2.8, 92);
+
+DELIMITER ;;
+CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_particle_classification`(
+  INOUT p_id int unsigned,
+  p_particleClassificationGroupId int unsigned,
+  p_classNumber int unsigned,
+  p_classImageFullPath varchar(255),
+  p_particlesPerClass int unsigned,
+  p_rotationAccuracy int unsigned,
+  p_translationAccuracy float,
+  p_estimatedResolution float,
+  p_overallFourierCompleteness float
+ )
+  MODIFIES SQL DATA
+  COMMENT 'Inserts or updates info about a particle classification (p_id).\nMandatory columns:\nFor insert: p_particleClassificationGroupId\nFor update: p_id \nReturns: Record ID in p_id.'
+BEGIN
+  IF p_id IS NOT NULL OR p_particleClassificationGroupId IS NOT NULL THEN
+    INSERT INTO ParticleClassification (particleClassificationId, 
+      particleClassificationGroupId, classNumber, classImageFullPath, 
+      particlesPerClass, rotationAccuracy, translationAccuracy, 
+      estimatedResolution, overallFourierCompleteness)
+      VALUES (p_id, p_particleClassificationGroupId, p_classNumber, 
+        p_classImageFullPath, 
+        p_particlesPerClass, p_rotationAccuracy, p_translationAccuracy, 
+        p_estimatedResolution, p_overallFourierCompleteness)
+      ON DUPLICATE KEY UPDATE
+        particleClassificationGroupId = IFNULL(p_particleClassificationGroupId, particleClassificationGroupId),
+        classNumber = IFNULL(p_classNumber, classNumber),
+        classImageFullPath = IFNULL(p_classImageFullPath, classImageFullPath),
+        particlesPerClass = IFNULL(p_particlesPerClass, particlesPerClass),
+        rotationAccuracy = IFNULL(p_rotationAccuracy, rotationAccuracy),
+        translationAccuracy = IFNULL(p_translationAccuracy, translationAccuracy),
+        estimatedResolution = IFNULL(p_estimatedResolution, estimatedResolution),
+        overallFourierCompleteness = IFNULL(p_overallFourierCompleteness, overallFourierCompleteness);
+
+    IF p_id IS NULL THEN
+      SET p_id = LAST_INSERT_ID();
+    END IF;
+  ELSE
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument(s) are NULL: p_id OR p_particleClassificationGroupId must be non-NULL.';
+  END IF;
+END;;
+DELIMITER ;

--- a/schemas/ispyb/stored_programs/sp_upsert_particle_classification_group.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_particle_classification_group.sql
@@ -1,0 +1,50 @@
+-- Example calls:
+--
+-- -- First create a Movie, a MotionCorrection and a ParticlePicker:
+--
+-- SET @mid := NULL;
+-- SET @mcid := NULL;
+-- CALL upsert_movie(@mid, 6017405, NULL, NULL, NULL, NULL, NULL, NULL);
+-- CALL upsert_motion_correction(@mcid, @mid, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+-- SET @ppid := NULL;
+-- CALL upsert_particle_picker(@ppid, @mcid, NULL, 'pp template 1', 8.1, 151);
+
+-- Then call this procedure:
+-- SET @pcgid := NULL;
+-- CALL upsert_particle_classification_group(@pcgid, @ppid, NULL, '2D', 1, 1300, 2, 'P222');
+
+DELIMITER ;;
+CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_particle_classification_group`(
+  INOUT p_id int(11) unsigned,
+  p_particlePickerId int(11) unsigned,
+  p_programId int(11) unsigned,
+  p_type varchar(10),
+  p_batchNumber int unsigned,
+  p_numberOfParticlesPerBatch int unsigned,
+  p_numberOfClassesPerBatch int unsigned,
+  p_symmetry varchar(20)
+ )
+  MODIFIES SQL DATA
+  COMMENT 'Inserts or updates info about a particle classification group (p_id).\nMandatory columns:\nFor insert: p_particlePickerId\nFor update: p_id \nReturns: Record ID in p_id.'
+BEGIN
+  IF p_id IS NOT NULL OR p_particlePickerId IS NOT NULL THEN
+    INSERT INTO ParticleClassificationGroup (particleClassificationGroupId, particlePickerId, programId, type, batchNumber, numberOfParticlesPerBatch,
+      numberOfClassesPerBatch, symmetry)
+      VALUES (p_id, p_particlePickerId, p_programId, p_type, p_batchNumber, p_numberOfParticlesPerBatch, p_numberOfClassesPerBatch, p_symmetry)
+      ON DUPLICATE KEY UPDATE
+        particlePickerId = IFNULL(p_particlePickerId, particlePickerId),
+        programId = IFNULL(p_programId, programId),
+        type = IFNULL(p_type, type),
+        batchNumber = IFNULL(p_batchNumber, batchNumber),
+        numberOfParticlesPerBatch = IFNULL(p_numberOfParticlesPerBatch, numberOfParticlesPerBatch),
+        numberOfClassesPerBatch = IFNULL(p_numberOfClassesPerBatch, numberOfClassesPerBatch),
+        symmetry = IFNULL(p_symmetry, symmetry);
+
+    IF p_id IS NULL THEN
+      SET p_id = LAST_INSERT_ID();
+    END IF;
+  ELSE
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument(s) are NULL: p_id OR p_particlePickerId must be non-NULL.';
+  END IF;
+END;;
+DELIMITER ;

--- a/schemas/ispyb/stored_programs/sp_upsert_particle_picker.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_particle_picker.sql
@@ -1,0 +1,43 @@
+-- Example calls:
+-- First create a Movie and a MotionCorrection:
+--
+-- SET @mid := NULL;
+-- SET @mcid := NULL;
+-- CALL upsert_movie(@mid, 6017405, NULL, NULL, NULL, NULL, NULL, NULL);
+-- CALL upsert_motion_correction(@mcid, @mid, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+--
+-- Then call this procedure:
+-- SET @ppid := NULL;
+-- CALL upsert_particle_picker(@ppid, @mcid, NULL, 'pp template 1', 8.1, 151);
+--
+
+DELIMITER ;;
+CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_particle_picker`(
+  INOUT p_id int(11) unsigned,
+  p_firstMotionCorrectionId int(11) unsigned,
+  p_programId int(11) unsigned,
+  p_particlePickingTemplate varchar(255),
+  p_particleDiameter float,
+  p_numberOfParticles int unsigned
+ )
+  MODIFIES SQL DATA
+  COMMENT 'Inserts or updates info about a particle picker (p_id).\nMandatory columns:\nFor insert: p_firstMotionCorrectionId\nFor update: p_id \nReturns: Record ID in p_id.'
+BEGIN
+  IF p_id IS NOT NULL OR p_firstMotionCorrectionId IS NOT NULL THEN
+    INSERT INTO ParticlePicker (particlePickerId, firstMotionCorrectionId, programId, particlePickingTemplate, particleDiameter, numberOfParticles)
+      VALUES (p_id, p_firstMotionCorrectionId, p_programId, p_particlePickingTemplate, p_particleDiameter, p_numberOfParticles)
+      ON DUPLICATE KEY UPDATE
+        firstMotionCorrectionId = IFNULL(p_firstMotionCorrectionId, firstMotionCorrectionId),
+        programId = IFNULL(p_programId, programId),
+        particlePickingTemplate = IFNULL(p_particlePickingTemplate, particlePickingTemplate),
+        particleDiameter = IFNULL(p_particleDiameter, particleDiameter),
+        numberOfParticles = IFNULL(p_numberOfParticles, numberOfParticles);
+
+    IF p_id IS NULL THEN
+      SET p_id = LAST_INSERT_ID();
+    END IF;
+  ELSE
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument(s) are NULL: p_id OR p_firstMotionCorrectionId must be non-NULL.';
+  END IF;
+END;;
+DELIMITER ;

--- a/schemas/ispyb/updates/2021_05_12_ParticleClassification_rotationAccuracy.sql
+++ b/schemas/ispyb/updates/2021_05_12_ParticleClassification_rotationAccuracy.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_05_12_ParticleClassification_rotationAccuracy.sql', 'ONGOING');
+
+ALTER TABLE `ParticleClassification`
+  MODIFY rotationAccuracy float COMMENT '???';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' where scriptName = '2021_05_12_ParticleClassification_rotationAccuracy.sql';


### PR DESCRIPTION
Here are 4 new stored procedures to populate the 5 new tables for cryoEM:

- `upsert_particle_picker`
- `upsert_particle_classification_group`
- `upsert_particle_classification`
- `insert_cryoem_initial_model`

Each one does what the name suggests. That last one populates both `CryoemInitialModel` and `ParticleClassification_has_CryoemInitialModel`. 

You will have to call them in this order so that you can pass in the value of the parent PK id when creating the child rows.

Example calls are in inline comments in each file.