### PR TITLE
Add BLSampleGroup.proposalId, FK constr. + populate

### DIFF
--- a/schemas/ispyb/updates/2021_06_01_BLSampleGroup_fk_proposalId.sql
+++ b/schemas/ispyb/updates/2021_06_01_BLSampleGroup_fk_proposalId.sql
@@ -1,0 +1,17 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_06_01_BLSampleGroup_fk_proposalId.sql', 'ONGOING');
+
+ALTER TABLE BLSampleGroup
+  ADD proposalId int(10) unsigned,
+  ADD CONSTRAINT BLSampleGroup_fk_proposalId
+    FOREIGN KEY (`proposalId`) 
+      REFERENCES `Proposal` (`proposalId`) 
+        ON DELETE SET NULL ON UPDATE CASCADE;
+
+UPDATE BLSampleGroup sg
+  JOIN BLSampleGroup_has_BLSample sghs ON sghs.blSampleGroupId = sg.blSampleGroupId
+  JOIN BLSample s ON s.blSampleId = sghs.blSampleId
+  JOIN Crystal c ON c.crystalId = s.crystalId
+  JOIN Protein p ON p.proteinId = c.proteinId
+SET sg.proposalId = p.proposalId;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_06_01_BLSampleGroup_fk_proposalId.sql';


### PR DESCRIPTION
Currently, we can't really create a sample group without simultaneously adding samples to it because the samples are needed to link it to a proposal.

This PR adds a `proposalId` column to `BLSampleGroup` + a FK constraint, and populates it based on its `BLSamples -> Crystal -> Protein.proposalId`.

Seems to work on our backup database.