### PR TITLE
Add col AutoProcScalingStatistics.resIOverSigI2 to capture resolution when I/Sig(I) <= 2

### DIFF
--- a/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resIOverSigI2.sql
+++ b/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resIOverSigI2.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_08_AutoProcScalingStatistics_resIOverSigI2.sql', 'ONGOING');
+
+ALTER TABLE AutoProcScalingStatistics
+  ADD resIOverSigI2 float COMMENT 'Resolution where I/Sigma(I) equals 2';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_08_AutoProcScalingStatistics_resIOverSigI2.sql';
+

--- a/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql
+++ b/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql', 'ONGOING');
+
+ALTER TABLE AutoProcScalingStatistics
+  ADD resWIOverSigIDropsBelow2 float COMMENT 'The resolution where (I)/sd(I) drops below 2';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql';

--- a/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql
+++ b/schemas/ispyb/updates/2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql
@@ -1,6 +1,0 @@
-INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql', 'ONGOING');
-
-ALTER TABLE AutoProcScalingStatistics
-  ADD resWIOverSigIDropsBelow2 float COMMENT 'The resolution where (I)/sd(I) drops below 2';
-
-UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_08_AutoProcScalingStatistics_resWIOverSigIDropsBelow2.sql';


### PR DESCRIPTION
It has been agreed at Diamond that it's a good idea to store the resolution value for when I/SigI drops below 2. 