### PR TITLE
Add Associate role for proposals and sessions

### DIFF
--- a/schemas/ispyb/updates/2021_07_09_ProposalHasPerson_role_enum.sql
+++ b/schemas/ispyb/updates/2021_07_09_ProposalHasPerson_role_enum.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_09_ProposalHasPerson_role_enum.sql', 'ONGOING');
+
+ALTER TABLE ProposalHasPerson MODIFY `role` enum('Co-Investigator','Principal Investigator','Alternate Contact', 'ERA Admin', 'Associate') DEFAULT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_09_ProposalHasPerson_role_enum.sql';

--- a/schemas/ispyb/updates/2021_07_09_Session_has_Person_role_enum.sql
+++ b/schemas/ispyb/updates/2021_07_09_Session_has_Person_role_enum.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_09_Session_has_Person_role_enum.sql', 'ONGOING');
+
+ALTER TABLE Session_has_Person MODIFY `role` enum('Local Contact','Local Contact 2','Staff','Team Leader','Co-Investigator','Principal Investigator','Alternate Contact','Data Access','Team Member', 'ERA Admin', 'Associate') DEFAULT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_09_Session_has_Person_role_enum.sql';


### PR DESCRIPTION
A new role 'Associate' has been created in the user admin system, so we need to have that in the ispyb database as well.

This PR adds an 'Associate' enum option to the `role` column in the `ProposalHasPerson` and `Session_has_Person` tables.