### PR TITLE
Add a source column to the PDB table

### DIFF
--- a/schemas/ispyb/updates/2021_07_27_PDB_source.sql
+++ b/schemas/ispyb/updates/2021_07_27_PDB_source.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_07_27_PDB_source.sql', 'ONGOING');
+
+ALTER TABLE PDB 
+  ADD `source` varchar(30) DEFAULT NULL COMMENT 'Could be e.g. AlphaFold or RoseTTAFold';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_07_27_PDB_source.sql';


### PR DESCRIPTION
A column to indicate the source of the PDB, e.g. AlphaFold. 

I suggest using a `varchar` rather than `enum` since programs change and I don't want to have to do `ALTER TABLE` whenever that happens.