### PR TITLE
Index to improve perf. of sproc upsert_sample_image_auto_score

### DIFF
--- a/schemas/ispyb/updates/2021_11_12_BLSampleImage_fullImagePath_idx.sql
+++ b/schemas/ispyb/updates/2021_11_12_BLSampleImage_fullImagePath_idx.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2021_11_12_BLSampleImage_fullImagePath_idx.sql', 'ONGOING');
+
+CREATE UNIQUE INDEX BLSampleImage_imageFullPath ON BLSampleImage(imageFullPath);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2021_11_12_BLSampleImage_fullImagePath_idx.sql';


### PR DESCRIPTION
Currently, the VMXi image uploader is spending a significant portion of its time inserting scoring results to the database.

Each sample image gets 4 scoring results. A call to a stored procedure `upsert_sample_image_auto_score` is made for each of these. The procedure has to look up the `blSampleImageId` for a given sample image identified by its full path. This lookup appears to take a long time, but by adding a unique index on the column the lookup will take virtually no time.