### PR TITLE
DiffractionPlan.scanParameters

### DIFF
--- a/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
+++ b/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
@@ -1,6 +1,6 @@
 INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_diffractionplan_scanparameters.sql', 'ONGOING');
 
 ALTER TABLE DiffractionPlan
-    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`)) COMMENT 'JSON seralised scan parameters, useful for parameters without designated columns';
+    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`)) COMMENT 'JSON serialised scan parameters, useful for parameters without designated columns';
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_diffractionplan_scanparameters.sql';

--- a/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
+++ b/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_diffractionplan_scanparameters.sql', 'ONGOING');
+
+ALTER TABLE DiffractionPlan
+    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`));
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_diffractionplan_scanparameters.sql';

--- a/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
+++ b/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
@@ -1,6 +1,6 @@
 INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_diffractionplan_scanparameters.sql', 'ONGOING');
 
 ALTER TABLE DiffractionPlan
-    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`)) COMMENT 'JSON serialised scan parameters, useful for parameters without designated columns';
+    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'JSON serialised scan parameters, useful for parameters without designated columns' CHECK (json_valid(`scanParameters`));
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_diffractionplan_scanparameters.sql';

--- a/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
+++ b/schemas/ispyb/updates/2022_06_28_diffractionplan_scanparameters.sql
@@ -1,6 +1,6 @@
 INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_diffractionplan_scanparameters.sql', 'ONGOING');
 
 ALTER TABLE DiffractionPlan
-    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`));
+    ADD `scanParameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`scanParameters`)) COMMENT 'JSON seralised scan parameters, useful for parameters without designated columns';
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_diffractionplan_scanparameters.sql';


### PR DESCRIPTION
As discussed adds `scanParameters` to `DiffractionPlan` which mirrors the column in `DataCollection`. The idea is to store parameters that cannot be described by existing columns or may change with some frequency (a json blob to represent a series of params).

I think Jake uses the `DataCollection` counter-part to store beamline parameters not described by `DataCollection`