### PR TITLE
GridInfo.patches

### DIFF
--- a/schemas/ispyb/updates/2022_06_28_gridinfo_patches.sql
+++ b/schemas/ispyb/updates/2022_06_28_gridinfo_patches.sql
@@ -1,7 +1,7 @@
 INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_gridinfo_patches.sql', 'ONGOING');
 
 ALTER TABLE GridInfo
-    ADD patches_x int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the X direction',
-    ADD patches_y int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the Y direction';
+    ADD patchesX int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the X direction',
+    ADD patchesY int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the Y direction';
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_gridinfo_patches.sql';

--- a/schemas/ispyb/updates/2022_06_28_gridinfo_patches.sql
+++ b/schemas/ispyb/updates/2022_06_28_gridinfo_patches.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_gridinfo_patches.sql', 'ONGOING');
+
+ALTER TABLE GridInfo
+    ADD patches_x int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the X direction',
+    ADD patches_y int(10) DEFAULT 1 COMMENT 'Number of patches the grid is made up of in the Y direction';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_gridinfo_patches.sql';


### PR DESCRIPTION
Allows a grid/mesh scan to define how many patches it is made up of. On imaging beamlines they are sometimes restricted by the throw of the relevant motors so are forced to conduct multiple gridscans in x,y to cover a larger area ("patches"). By specifying how many patches in x, and y we can properly reconstruct the raw data into maps