### PR TITLE
Add sampleimage positioners

### DIFF
--- a/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
+++ b/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
@@ -12,6 +12,6 @@ CREATE TABLE `BLSampleImage_has_Positioner` (
     CONSTRAINT `BLSampleImageHasPositioner_ibfk2`
         FOREIGN KEY (`positionerId`)
             REFERENCES `Positioner`(`positionerId`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Allows a BLSampleImage to store motor positions along with the image';
+    ) ENGINE=InnoDB COMMENT='Allows a BLSampleImage to store motor positions along with the image';
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_sampleimage_positioner.sql';

--- a/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
+++ b/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
@@ -8,8 +8,7 @@ CREATE TABLE `BLSampleImage_has_Positioner` (
     PRIMARY KEY (`blSampleImageHasPositionerId`),
     CONSTRAINT `BLSampleImageHasPositioner_ibfk1`
         FOREIGN KEY (`blSampleImageId`)
-            REFERENCES `BLSampleImage`(`blSampleImageId`)
-                ON DELETE RESTRICT ON UPDATE RESTRICT,
+            REFERENCES `BLSampleImage`(`blSampleImageId`),
     CONSTRAINT `BLSampleImageHasPositioner_ibfk2`
         FOREIGN KEY (`positionerId`)
             REFERENCES `Positioner`(`positionerId`)

--- a/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
+++ b/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
@@ -13,6 +13,6 @@ CREATE TABLE `BLSampleImage_has_Positioner` (
     CONSTRAINT `BLSampleImageHasPositioner_ibfk2`
         FOREIGN KEY (`positionerId`)
             REFERENCES `Positioner`(`positionerId`)
-    );
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Allows a BLSampleImage to store motor positions along with the image';
 
 UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_sampleimage_positioner.sql';

--- a/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
+++ b/schemas/ispyb/updates/2022_06_28_sampleimage_positioner.sql
@@ -1,0 +1,18 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2022_06_28_sampleimage_positioner.sql', 'ONGOING');
+
+CREATE TABLE `BLSampleImage_has_Positioner` (
+    `blSampleImageHasPositionerId` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `blSampleImageId` INT UNSIGNED NOT NULL,
+    `positionerId` INT UNSIGNED NOT NULL,
+    `value` float COMMENT 'The position of this positioner for this blsampleimage',
+    PRIMARY KEY (`blSampleImageHasPositionerId`),
+    CONSTRAINT `BLSampleImageHasPositioner_ibfk1`
+        FOREIGN KEY (`blSampleImageId`)
+            REFERENCES `BLSampleImage`(`blSampleImageId`)
+                ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT `BLSampleImageHasPositioner_ibfk2`
+        FOREIGN KEY (`positionerId`)
+            REFERENCES `Positioner`(`positionerId`)
+    );
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2022_06_28_sampleimage_positioner.sql';


### PR DESCRIPTION
We would like to store one or more `Positioner`s with a `BLSampleImage`, primary to define the z motor position so that rois/pois can be bought back into focus from a sample image where there is no online axis camera.

This table will work both with and without https://github.com/DiamondLightSource/ispyb-database/pull/105 (i'm not ready to deploy the changes in https://github.com/DiamondLightSource/ispyb-database/pull/105 yet at ESRF)