### PR TITLE
Only create update-schema-sql PR on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,3 @@ jobs:
               Before merging this pull request you may want to:
               * [ ] Update `HISTORY.md` to reflect the changes in this pull request
             branch: update-schema-sql
-            branch-suffix: short-commit-hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        if: github.ref == 'refs/heads/master'
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             commit-message: Update database sql files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           rm ../.my.cnf
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: github.ref == 'refs/heads/master'
         with:
             token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Don't use branch-suffix: this is the default and will continually update a pull request with new changes until it is merged or closed. I think this is probably preferable to creating a separate PR for every push to master.

See also https://github.com/marketplace/actions/create-pull-request#alternative-strategy---always-create-a-new-pull-request-branch

Update to peter-evans/create-pull-request@v4