### PR TITLE
New columns GridInfo.micronsPerPixelX + Y and Detector.numberOfROIPixelsX + Y

### DIFF
--- a/bin/lookup_tables.sh
+++ b/bin/lookup_tables.sh
@@ -31,7 +31,7 @@ ScanParametersService
 EventType
 LDAPSearchParameters
 LDAPSearchBase
-UserGroup_has_LDAPGroup
+UserGroup_has_LDAPSearchParameters
 )
 
 LOOKUP_TABLES_STRING=''

--- a/schemas/ispyb/updates/2023_03_27_Detector_numberOfROIPixelsXY.sql
+++ b/schemas/ispyb/updates/2023_03_27_Detector_numberOfROIPixelsXY.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_03_27_Detector_numberOfROIPixelsXY.sql', 'ONGOING');
+
+ALTER TABLE Detector
+  ADD numberOfROIPixelsX mediumint DEFAULT NULL COMMENT 'Detector number of pixels in x in ROI mode',
+  ADD numberOfROIPixelsY mediumint DEFAULT NULL COMMENT 'Detector number of pixels in y in ROI mode';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_03_27_Detector_numberOfROIPixelsXY.sql';

--- a/schemas/ispyb/updates/2023_03_27_GridInfo_micronsPerPixelXY.sql
+++ b/schemas/ispyb/updates/2023_03_27_GridInfo_micronsPerPixelXY.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_03_27_GridInfo_micronsPerPixelXY.sql', 'ONGOING');
+
+ALTER TABLE GridInfo
+  ADD micronsPerPixelX float DEFAULT NULL,
+  ADD micronsPerPixelY float DEFAULT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_03_27_GridInfo_micronsPerPixelXY.sql';


### PR DESCRIPTION
As per internal ticket LIMS-560 we want to add the following two columns to the `Detector` table:
* `numberOfROIPixelsX`
* `numberOfROIPixelsY`

As per internal ticket LIMS-570 we want to add the following two columns to the `GridInfo` table:
* `micronsPerPixelX`
* `micronsPerPixelY`

(The `micronsPerPixelX` and `Y` columns will eventually replace the `pixelPerMicronsX` and `Y` columns, but we will have both sets in a transition period.)

This PR also fixes a mis-typed table name in `bin/lookup_tables.sh`.