### PR TITLE
New XrayCentring/XrayCentringResult tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 Unreleased / master
 -------------------
 
+* New tables for storing X-ray centring results:
+  * ``XrayCentring``
+  * ``XrayCentringResult`` (replaces unused/legacy ``XrayCentringResult`` table)
+
 * New columns:
 
   * In ``Detector`` table: ``numberOfROIPixelsX`` + ``numberOfROIPixelsY`` (for ROI mode) 

--- a/schemas/ispyb/updates/2023_04_04_XrayCentringResult.sql
+++ b/schemas/ispyb/updates/2023_04_04_XrayCentringResult.sql
@@ -1,0 +1,33 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_04_04_XrayCentring.sql', 'ONGOING');
+
+CREATE TABLE `XrayCentring`(
+    `xrayCentringId` int(11) unsigned PRIMARY KEY AUTO_INCREMENT,
+    `dataCollectionGroupId` int(11) NOT NULL COMMENT 'references DataCollectionGroup table',
+    `status` enum ('success', 'failed', 'pending'),
+    `xrayCentringType` enum ('2d', '3d'),
+    FOREIGN KEY (`dataCollectionGroupId`) REFERENCES `DataCollectionGroup`(`dataCollectionGroupId`) ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARSET = utf8mb4 COMMENT = 'Xray Centring analysis associated with one or more grid scans.';
+
+DROP TABLE IF EXISTS `XrayCentringResult`;
+
+CREATE TABLE `XrayCentringResult`(
+    `xrayCentringResultId` int(11) unsigned PRIMARY KEY AUTO_INCREMENT,
+    `xrayCentringId` int(11) unsigned NOT NULL COMMENT 'references XrayCentring table',
+    `centreOfMassX` float DEFAULT NULL COMMENT 'x-coordinate corresponding to the centre of mass of the crystal (in voxels)',
+    `centreOfMassY` float DEFAULT NULL COMMENT 'y-coordinate corresponding to the centre of mass of the crystal (in voxels)',
+    `centreOfMassZ` float DEFAULT NULL COMMENT 'z-coordinate corresponding to the centre of mass of the crystal (in voxels)',
+    `maxVoxelX` int DEFAULT NULL COMMENT 'x-coordinate of the voxel with the maximum value within this crystal volume',
+    `maxVoxelY` int DEFAULT NULL COMMENT 'y-coordinate of the voxel with the maximum value within this crystal volume',
+    `maxVoxelZ` int DEFAULT NULL COMMENT 'z-coordinate of the voxel with the maximum value within this crystal volume',
+    `numberOfVoxels` int DEFAULT NULL COMMENT 'Number of voxels within the specified bounding box',
+    `totalCount` float DEFAULT NULL COMMENT 'The sum of the values of all the voxels within the specified bounding box',
+    `boundingBoxMinX` float DEFAULT NULL COMMENT 'Minimum x-coordinate of the bounding box containing the crystal (in voxels)',
+    `boundingBoxMaxX` float DEFAULT NULL COMMENT 'Maximum x-coordinate of the bounding box containing the crystal (in voxels)',
+    `boundingBoxMinY` float DEFAULT NULL COMMENT 'Minimum y-coordinate of the bounding box containing the crystal (in voxels)',
+    `boundingBoxMaxY` float DEFAULT NULL COMMENT 'Maximum y-coordinate of the bounding box containing the crystal (in voxels)',
+    `boundingBoxMinZ` float DEFAULT NULL COMMENT 'Minimum z-coordinate of the bounding box containing the crystal (in voxels)',
+    `boundingBoxMaxZ` float DEFAULT NULL COMMENT 'Maximum z-coordinate of the bounding box containing the crystal (in voxels)',
+    FOREIGN KEY (`xrayCentringId`) REFERENCES `XrayCentring`(`xrayCentringId`) ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARSET = utf8mb4 COMMENT = 'Xray Centring result.';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_04_04_XrayCentring.sql';


### PR DESCRIPTION
Replace unused/legacy XrayCentringResult table

Relationship to existing tables shown using [dbdiagram.io](https://dbdiagram.io/):
```
Table XrayCenteringResult {
  id int [pk, increment]
  xrayCenteringId int [ref: > XrayCentering.id] // many-to-one
  centreOfMassX float
  centreOfMassY float
  centreOfMassZ float
  maxVoxelX int
  maxVoxelY int
  maxVoxelZ int
  numberOfVoxels int
  totalCount float
  boundingBoxMinX float
  boundingBoxMinY float
  boundingBoxMinZ float
  boundingBoxMaxX float
  boundingBoxMaxY float
  boundingBoxMaxZ float
}

Table XrayCentering {
  id int [pk, increment]
  dataCollectionGroupId int [ref: > DataCollectionGroup.dataCollectionGroupId]
  status XrayCenteringStatus
  xrayCenteringType XrayCenteringType
}

Enum XrayCenteringType {
  2d
  3d
}

Enum XrayCenteringStatus {
  success
  failed
  pending
}

Table DataCollectionGroup {
  dataCollectionGroupId int [pk, increment]
}

Table DataCollection {
  dataCollectionId int [pk, increment]
  dataCollectionGroupId int [ref: > DataCollectionGroup.dataCollectionGroupId]
}

Table GridInfo {
  gridInfoId int [pk, increment]
  dataCollectionId int [ref: > DataCollection.dataCollectionId]
}
```
![image](https://user-images.githubusercontent.com/2810624/229840968-49d1a33c-cac5-4497-9865-7ba3bda578cc.png)
