### PR TITLE
Improved formatting of table + sproc documentation

### DIFF
--- a/bin/db_procs_to_rst.sh
+++ b/bin/db_procs_to_rst.sh
@@ -4,16 +4,13 @@ db=$1
 
 file=$(mktemp /tmp/tsv.XXXXXX)
 
-# Substitute $file with its value in the sql file
-sql=$(env file=${file} envsubst < sql/db_procs_to_tsv.sql)
-
 # Execute the sql to generate the csv outfile
-mysql --defaults-file=../.my.cnf --skip-column-names --batch --raw -D $db -e "${sql}" > ${file}
+mysql --defaults-file=../.my.cnf --skip-column-names --batch --raw -D $db < sql/db_procs_to_tsv.sql  > ${file}
 
 # Construct rst file with csv table
 echo ".. csv-table:: Procedure signatures with comments"
-echo '   :header: "Name", "Params", "Comment"'
-echo "   :widths: 20, 30, 50"
+echo '   :header: "Name", "Params", "Users/roles", "Comment"'
+echo "   :widths: 20, 30, 10, 40"
 echo ""
 
 while read p; do

--- a/bin/db_tables_to_rst.sh
+++ b/bin/db_tables_to_rst.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 db=$1
-mysql --defaults-file=../.my.cnf -D $db --skip-column-names --batch --raw < sql/db_tables_to_tsv.sql > /tmp/tmp1.tsv
-sed -i.tmp 's/\t/,/g' /tmp/tmp1.tsv
+
+file=$(mktemp /tmp/tsv.XXXXXX)
+
+mysql --defaults-file=../.my.cnf -D $db --skip-column-names --batch --raw < sql/db_tables_to_tsv.sql > ${file}
+sed -i 's/\t/,/g' ${file}
 
 echo ".. csv-table:: Tables, columns and comments"
 echo '   :header: "Name", "Type", "Comment"'
@@ -11,4 +14,6 @@ echo ""
 
 while read p; do
   echo "   $p"
-done </tmp/tmp1.tsv
+done <${file}
+
+rm ${file}

--- a/bin/sql/db_procs_to_tsv.sql
+++ b/bin/sql/db_procs_to_tsv.sql
@@ -1,20 +1,11 @@
 SELECT concat('"**', r.ROUTINE_NAME, '**",') as "name",
     concat('"', trim(REPLACE(REPLACE(REPLACE(REPLACE(p.param_list, '\n', ' '), '\r', ' '), '\t', ' '), '"', '')), '",') as "params",
+    concat('"', IFNULL(GROUP_CONCAT(DISTINCT pp.user ORDER BY pp.user SEPARATOR ', '), 'none'), '",') as "users",
     concat('"', REPLACE(r.ROUTINE_COMMENT, '"', ''), '"') as "comment"
---    ,r.LAST_ALTERED as "modified"
---    ,GROUP_CONCAT(pp.user) as "users"
--- INTO OUTFILE '${file}'
--- FIELDS TERMINATED BY ','
--- ENCLOSED BY '"'
--- -- FIELDS ESCAPED BY '\'
--- LINES TERMINATED BY '\n'
 FROM information_schema.ROUTINES r
---    LEFT OUTER JOIN mysql.procs_priv pp ON pp.routine_name = r.routine_name
     INNER JOIN mysql.proc p ON p.name = r.routine_name AND p.db = r.ROUTINE_SCHEMA
+    LEFT OUTER JOIN mysql.procs_priv pp ON r.routine_name = pp.Routine_name AND r.ROUTINE_SCHEMA = pp.Db
 WHERE r.ROUTINE_SCHEMA = database()
     AND r.ROUTINE_TYPE = 'PROCEDURE'
--- GROUP BY r.ROUTINE_NAME,
---    r.ROUTINE_COMMENT,
---    r.LAST_ALTERED,
---    TRIM(REPLACE(REPLACE(REPLACE(p.param_list, '\n', ' '), '\r', ' '), '\t', ' '))
-ORDER BY ROUTINE_NAME ASC;
+GROUP BY r.ROUTINE_NAME, p.param_list, r.ROUTINE_COMMENT
+ORDER BY r.ROUTINE_NAME ASC;

--- a/build.sh
+++ b/build.sh
@@ -54,9 +54,9 @@ then
   elif [ -d "bin" ]; then
     cd bin
     ./db_procs_to_rst.sh $DB > /tmp/list_of_procs.rst
-    pandoc -o /tmp/list_of_procs.html /tmp/list_of_procs.rst
+    pandoc --self-contained --metadata title:"List or procedures" -c ../docs/list.css -o /tmp/list_of_procs.html /tmp/list_of_procs.rst
     ./db_tables_to_rst.sh $DB > /tmp/list_of_tables_and_columns.rst
-    pandoc -o /tmp/list_of_tables_and_columns.html /tmp/list_of_tables_and_columns.rst
+    pandoc --self-contained --metadata title:"List or tables and columns" -c ../docs/list.css -o /tmp/list_of_tables_and_columns.html /tmp/list_of_tables_and_columns.rst
     echo "HTML documentation written to files in /tmp/"
     cd ..
   fi

--- a/docs/list.css
+++ b/docs/list.css
@@ -1,0 +1,12 @@
+table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+td {
+  word-wrap: break-word;;
+}
+
+tr.even {
+  background-color: whitesmoke;  
+}


### PR DESCRIPTION
- Make the given column widths actually take effect
- Add a users/roles column in the list of procedures
- Use slightly different colours on even numbered rows in the tables for improved readability
- Remove commented-out code
- Remove unnecessary code
- Use `mktemp` to create tmp file also in `db_tables_to_rst.sh`