### PR TITLE
HTML list of procs: Replace comma sep with linebreak in params and user/roles cols

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,10 +53,13 @@ then
     echo "'pandoc' was not found in PATH: skipping documentation generation"
   elif [ -d "bin" ]; then
     cd bin
-    ./db_procs_to_rst.sh $DB > /tmp/list_of_procs.rst
-    pandoc --self-contained --metadata title:"List or procedures" -c ../docs/list.css -o /tmp/list_of_procs.html /tmp/list_of_procs.rst
+    ./db_procs_to_rst.sh ${DB} > /tmp/list_of_procs.rst
+    html_tmp=$(mktemp /tmp/procs.XXXXXX.tmp.html)
+    pandoc --self-contained --metadata title:"List of procedures" -c ../docs/list.css -o ${html_tmp} /tmp/list_of_procs.rst
+    awk -v RS='</tr>' -v FS='</td>' -v ORS='</tr>' -v OFS='</td>' '{gsub(", ", "<br>\n", $0); gsub(", ", "<br>\n", $1); printf("%s", $0)}' /tmp/list_of_procs.tmp.html > /tmp/list_of_procs.html
+    rm ${html_tmp}
     ./db_tables_to_rst.sh $DB > /tmp/list_of_tables_and_columns.rst
-    pandoc --self-contained --metadata title:"List or tables and columns" -c ../docs/list.css -o /tmp/list_of_tables_and_columns.html /tmp/list_of_tables_and_columns.rst
+    pandoc --self-contained --metadata title:"List of tables and columns" -c ../docs/list.css -o /tmp/list_of_tables_and_columns.html /tmp/list_of_tables_and_columns.rst
     echo "HTML documentation written to files in /tmp/"
     cd ..
   fi


### PR DESCRIPTION
In the HTML list of procedures:
* Fix spelling in the title ("or" -> "of")
* Use awk to replace ", " with line-break in the "Params" and the "User/roles" columns
