### PR TITLE
New cols Dewar.extra and ParticleClassificationGroup.selected

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Unreleased / master
 
 Removed procedures relating to old ``XrayCentringResult`` table removed in 1.36.0 (contributed by @DominicOram)
 
+New and modified columns:
+
+* In the ``Dewar`` table: ``extra`` JSON column for facility-specific or hard-to-define attributes.
+* In the ``ParticleClassificationGroup`` table: ``selected`` boolean to indicate that the group has been selected for processing.
+
 1.36.1 (2023-04-17)
 -------------------
 

--- a/schemas/ispyb/updates/2023_05_05_Dewar_extra.sql
+++ b/schemas/ispyb/updates/2023_05_05_Dewar_extra.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_05_05_Dewar_extra.sql', 'ONGOING');
+
+ALTER TABLE Dewar
+  ADD `extra` JSON DEFAULT NULL COMMENT 'JSON column for facility-specific or hard-to-define attributes, e.g. LN2 top-ups and contents checks' CHECK (json_valid(`extra`));
+
+-- Undo:
+-- ALTER TABLE Dewar
+--  DROP IF EXISTS extra;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_05_05_Dewar_extra.sql';

--- a/schemas/ispyb/updates/2023_05_05_ParticleClassificationGroup_selected.sql
+++ b/schemas/ispyb/updates/2023_05_05_ParticleClassificationGroup_selected.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_05_05_ParticleClassificationGroup_selected.sql', 'ONGOING');
+
+ALTER TABLE ParticleClassificationGroup
+  ADD selected boolean COMMENT 'Indicates whether the group is selected for processing or not.';
+
+-- Undo:
+-- ALTER TABLE ParticleClassificationGroup
+--  DROP IF EXISTS selected;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_05_05_ParticleClassificationGroup_selected.sql';


### PR DESCRIPTION
* In the ``Dewar`` table: ``extra`` JSON column for facility-specific or hard-to-define attributes.
* In the ``ParticleClassificationGroup`` table: ``selected`` boolean to indicate that the group has been selected for processing.
