### PR TITLE
Modify Dewar.comments from tinytext to varchar(1024)

### DIFF
--- a/schemas/ispyb/updates/2023_05_09_Dewar_modify_comments.sql
+++ b/schemas/ispyb/updates/2023_05_09_Dewar_modify_comments.sql
@@ -1,0 +1,8 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_05_09_Dewar_modify_comments.sql', 'ONGOING');
+
+ALTER TABLE Dewar MODIFY comments varchar(1024);
+
+-- Undo:
+-- ALTER TABLE Dewar MODIFY comments tinytext;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_05_09_Dewar_modify_comments.sql';


### PR DESCRIPTION
The `comments` column in the `Dewar` table is too small (tinytext is only 255 characters) so let's extend it to 1024 characters. 