### PR TITLE
Install pandoc package in Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: pandoc
+          version: 1.0
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           distribution: 'mariadb'


### PR DESCRIPTION
Install the pandoc package so that `build.sh` gets to test documentation auto-generation.   