### PR TITLE
Prevent stored procedures from writing NULL to DewarTransportHistory.storageLocation

### DIFF
--- a/schemas/ispyb/stored_programs/sp_update_container_assign.sql
+++ b/schemas/ispyb/stored_programs/sp_update_container_assign.sql
@@ -21,6 +21,10 @@ BEGIN
     DECLARE row_proposalNumber varchar(45) DEFAULT NULL;
     DECLARE row_queuedCount int(11) unsigned DEFAULT NULL;
 
+    IF p_beamline IS NULL THEN
+      SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument p_beamline is NULL';
+    END IF;
+
     IF NOT (p_registry_barcode IS NULL) THEN
         START TRANSACTION;
 

--- a/schemas/ispyb/stored_programs/sp_upsert_dewar.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_dewar.sql
@@ -24,6 +24,10 @@ CREATE OR REPLACE PROCEDURE `upsert_dewar`(
 BEGIN
     DECLARE row_storageLocation varchar(45) DEFAULT NULL;
 	  DECLARE row_dewarStatus varchar(45) DEFAULT NULL;
+		
+		IF p_storageLocation IS NULL THEN
+			SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument p_storageLocation is NULL';
+		END IF;
 
     IF p_id IS NULL THEN
 		  IF p_type IS NOT NULL THEN

--- a/schemas/ispyb/stored_programs/sp_upsert_dewar_v2.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_dewar_v2.sql
@@ -1,6 +1,6 @@
 -- Test:
 -- SET @id = NULL;
--- CALL upsert_dewar(@id, 'boaty', 6988, 'boatys dewar', NULL, '1', 'at facility', 0, 'DLS-MX-00101', NULL, 0, 0, NULL, NULL, 'Dewar', 'DLS-MX-00101', 5, NULL);
+-- CALL upsert_dewar_v2(@id, 'boaty', 6988, 'boatys dewar', NULL, '1', 'at facility', 0, 'DLS-MX-00101', NULL, 0, 0, NULL, NULL, 'Dewar', 'DLS-MX-00101', 5, NULL);
 -- 
 
 DELIMITER ;;
@@ -32,6 +32,10 @@ BEGIN
 	DECLARE row_storageLocation varchar(45) DEFAULT NULL;
 	DECLARE row_dewarStatus varchar(45) DEFAULT NULL;
   DECLARE row_count int unsigned DEFAULT 0;
+
+	IF p_storageLocation IS NULL THEN
+		SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Mandatory argument p_storageLocation is NULL';
+	END IF;
 
   IF p_authLogin IS NOT NULL AND p_shippingId IS NOT NULL THEN
 


### PR DESCRIPTION
To avoid NULL in DewarTransportHistory.storageLocation:
- Disallow NULL values for `p_storageLocation` param in `upsert_dewar` and `upsert_dewar_v2`
- Disallow NULL values for `p_beamline` param in `update_container_assign` 