### PR TITLE
Add catalog-info.yaml file for our developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: ispyb-database
+  title: ISPyB database
+  description: >
+    A database for experiement-related metadata such as data collections, processing, samples and shipments.
+    This is the Diamond-flavour of the ISPyB schema running on MariaDB Server.
+  annotations:
+    github.com/project-slug: DiamondLightSource/ispyb-database
+    diamond.ac.uk/viewdocs-url: https://diamondlightsource.github.io/ispyb-database/
+  links:
+    - url: https://confluence.diamond.ac.uk/x/15tTAQ
+      title: Documentation in Confluence
+    - url: https://github.com/DiamondLightSource/ispyb-database/wiki
+      title: Documentation in Github Wiki
+    - url: https://alfred.diamond.ac.uk/documentation/ispyb-database/list_of_tables_and_columns.html
+      title: Auto-generated list of database tables and columns 
+    - url: https://alfred.diamond.ac.uk/documentation/ispyb-database/list_of_procs.html
+      title: Auto-generated list of database stored procedures
+spec:
+  type: database
+  lifecycle: production
+  owner: group:lims
+  dependsOn: [resource:uas-database]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,4 +22,5 @@ spec:
   type: database
   lifecycle: production
   owner: group:lims
-  dependsOn: [resource:uas-database]
+  dependsOn:
+    - resource:uas-database

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ispyb-database
   title: ISPyB database
   description: >
-    A database for experiement-related metadata such as data collections, processing, samples and shipments.
+    A database for experiment-related metadata such as data collections, processing, samples and shipments.
     This is the Diamond-flavour of the ISPyB schema running on MariaDB Server.
   annotations:
     github.com/project-slug: DiamondLightSource/ispyb-database


### PR DESCRIPTION
This includes documentation links and has the owner as `group:lims`.