### PR TITLE
Self-referenting FK in Container table to allow hierarchy of Containers

### DIFF
--- a/schemas/ispyb/updates/2023_07_19_Container_parentContainerId.sql
+++ b/schemas/ispyb/updates/2023_07_19_Container_parentContainerId.sql
@@ -1,0 +1,12 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_07_19_Container_parentContainerId.sql', 'ONGOING');
+
+ALTER TABLE Container
+  ADD parentContainerId int(10) unsigned NULL DEFAULT NULL,
+  ADD CONSTRAINT `Container_fk_parentContainerId` FOREIGN KEY (`parentContainerId`) REFERENCES `Container` (`containerId`);
+
+-- Undo:
+-- ALTER TABLE Container
+--    DROP CONSTRAINT Container_fk_parentContainerId,
+--    DROP parentContainerId;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_07_19_Container_parentContainerId.sql';


### PR DESCRIPTION
Add a Container table column `parentContainerId` with a FK constraint referencing the Container table itself.

This will allow hierarchies of Containers within a Dewar.

Note that the dewarId column can be NULL, so we don't have to populate this except for the top-most Container.

(This is being added to fulfil requirements for EM sample handling, but may be useful elsewhere as well.)