### PR TITLE
Add containerTypeId FK for Screen table

### DIFF
--- a/schemas/ispyb/updates/2023_08_09_Screen_fk_containerTypeId.sql
+++ b/schemas/ispyb/updates/2023_08_09_Screen_fk_containerTypeId.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_08_09_Screen_fk_containerTypeId.sql', 'ONGOING');
+
+ALTER TABLE Screen
+  ADD containerTypeId int(10) unsigned,
+  ADD CONSTRAINT Screen_fk_containerTypeId FOREIGN KEY (containerTypeId) REFERENCES ContainerType(containerTypeId) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_08_09_Screen_fk_containerTypeId.sql';


### PR DESCRIPTION
Add a `containerTypeId` column and foreign key to the `Screen` table so that screens can be linked to particular plate types (container types).