### PR TITLE
Add unique key for ContainerRegistry.barcode and make it not nullable

### DIFF
--- a/schemas/ispyb/updates/2023_08_16_ContainerRegistry_barcode_unique_not_null.sql
+++ b/schemas/ispyb/updates/2023_08_16_ContainerRegistry_barcode_unique_not_null.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_08_16_ContainerRegistry_barcode_unique_not_null.sql', 'ONGOING');
+
+ALTER TABLE ContainerRegistry
+    MODIFY barcode varchar(20) NOT NULL,
+    ADD UNIQUE KEY ContainerRegistry_uniq_barcode (barcode);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_08_16_ContainerRegistry_barcode_unique_not_null.sql';


### PR DESCRIPTION
This barcode should never be null and it should also be unique, so let's enforce that by adding a unique key and redefining the column as `NOT NULL`.