### PR TITLE
Make Dewar.shippingId mandatory

### DIFF
--- a/schemas/ispyb/updates/2023_10_23_Dewar_modify_shippingId.sql
+++ b/schemas/ispyb/updates/2023_10_23_Dewar_modify_shippingId.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_10_23_Dewar_modify_shippingId.sql', 'ONGOING');
+
+ALTER TABLE Dewar
+    MODIFY shippingId int(10) unsigned NOT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_10_23_Dewar_modify_shippingId.sql';


### PR DESCRIPTION
Make `shippingId` in the `Dewar` table mandatory (i.e. not nullable).