### PR TITLE
Add a safetyLevel enum to the BLSession table to hold the ERA status

### DIFF
--- a/schemas/ispyb/updates/2023_10_24_BLSession_add_safetyLevel.sql
+++ b/schemas/ispyb/updates/2023_10_24_BLSession_add_safetyLevel.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2023_10_24_BLSession_add_safetyLevel.sql', 'ONGOING');
+
+ALTER TABLE BLSession
+    ADD safetyLevel enum('GREEN','YELLOW','RED') COMMENT 'Risk rating';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2023_10_24_BLSession_add_safetyLevel.sql';


### PR DESCRIPTION
Add an `enum('GREEN','YELLOW','RED')` column to the `BLSession` table.