### PR TITLE
Bug fix: remove refs to removed BLSession columns in sproc upsert_session_for_proposal_code_number

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ History
 Unreleased / master
 -------------------
 
+4.0.1 (2024-01-09)
+-------------------
+
+* Modify stored procedure ``upsert_session_for_proposal_code_number`` to remove
+  references in queries to previously removed ``BLSession`` columns.
+
 4.0.0 (2024-01-08)
 -------------------
 

--- a/schemas/ispyb/routines.sql
+++ b/schemas/ispyb/routines.sql
@@ -130,7 +130,7 @@ DELIMITER ;
 /*!50003 SET character_set_results = utf8mb3 */ ;
 /*!50003 SET collation_connection  = utf8mb3_general_ci */ ;
 DELIMITER ;;
-CREATE FUNCTION `retrieve_proposal_title`(p_proposal_code varchar(5), p_proposal_number int) RETURNS varchar(255) CHARSET latin1 COLLATE latin1_swedish_ci
+CREATE FUNCTION `retrieve_proposal_title`(p_proposal_code varchar(5), p_proposal_number int) RETURNS varchar(255) CHARSET latin1
     READS SQL DATA
 BEGIN
 	DECLARE ret_title varchar(255);
@@ -155,7 +155,7 @@ DELIMITER ;
 /*!50003 SET character_set_results = utf8mb3 */ ;
 /*!50003 SET collation_connection  = utf8mb3_general_ci */ ;
 DELIMITER ;;
-CREATE FUNCTION `retrieve_proposal_title_v2`(p_proposalCode varchar(5), p_proposalNumber int) RETURNS varchar(255) CHARSET latin1 COLLATE latin1_swedish_ci
+CREATE FUNCTION `retrieve_proposal_title_v2`(p_proposalCode varchar(5), p_proposalNumber int) RETURNS varchar(255) CHARSET latin1
     READS SQL DATA
     COMMENT 'Retrieve the title for a given proposal code and number.'
 BEGIN
@@ -206,7 +206,7 @@ DELIMITER ;
 /*!50003 SET character_set_results = utf8mb3 */ ;
 /*!50003 SET collation_connection  = utf8mb3_general_ci */ ;
 DELIMITER ;;
-CREATE FUNCTION `root_replace`(p_str varchar(255), p_oldroot varchar(255), p_newroot varchar(255)) RETURNS varchar(255) CHARSET latin1 COLLATE latin1_swedish_ci
+CREATE FUNCTION `root_replace`(p_str varchar(255), p_oldroot varchar(255), p_newroot varchar(255)) RETURNS varchar(255) CHARSET latin1
     COMMENT 'Returns a varchar where the old root p_oldroot (the leftmost part) of p_str has been replaced with a new root p_newroot'
 BEGIN
  DECLARE path_len smallint unsigned DEFAULT LENGTH(p_oldroot);
@@ -11840,13 +11840,11 @@ CREATE PROCEDURE `upsert_session_for_proposal_code_number`(
 	 p_startDate datetime,
 	 p_endDate datetime,
 	 p_beamlineName varchar(45),
-	 p_title varchar(255),
 	 p_beamlineOperator varchar(45),
 	 p_nbShifts int(10) unsigned,
 	 p_scheduled tinyint(1),
 	 p_usedFlag tinyint(1),
 	 p_comments varchar(255),
-	 p_externalPkId int(11) unsigned,
 	 p_externalPkUUID varchar(32)
  )
     MODIFIES SQL DATA
@@ -11872,9 +11870,9 @@ BEGIN
 
     IF row_session_id IS NULL THEN
       INSERT INTO BLSession(sessionId, proposalId, visit_number, beamLineSetupId, startDate, endDate,
-        beamLineName, sessionTitle, beamLineOperator, nbShifts, scheduled, usedFlag, comments, expSessionPk, externalId)
+        beamLineName, beamLineOperator, nbShifts, scheduled, usedFlag, comments, externalId)
         VALUES (p_id, row_proposal_id, p_visitNumber, p_beamLineSetupId, p_startDate, p_endDate,
-          p_beamlineName, p_title, p_beamlineOperator, p_nbShifts, p_scheduled, p_usedFlag, p_comments, p_externalPkId, unhex(p_externalPkUUID));
+          p_beamlineName, p_beamlineOperator, p_nbShifts, p_scheduled, p_usedFlag, p_comments, unhex(p_externalPkUUID));
       SET p_id = LAST_INSERT_ID();
 
     ELSE
@@ -11887,13 +11885,11 @@ BEGIN
         startDate = IFNULL(p_startDate, startDate),
         endDate = IFNULL(p_endDate, endDate),
         beamLineName = IFNULL(p_beamlineName, beamLineName),
-        sessionTitle = IFNULL(p_title, sessionTitle),
         beamLineOperator = IFNULL(p_beamlineOperator, beamLineOperator),
         nbShifts = IFNULL(p_nbShifts, nbShifts),
         scheduled = IFNULL(p_scheduled, scheduled),
         usedFlag = IFNULL(p_usedFlag, usedFlag),
         comments = IFNULL(p_comments, comments),
-        expSessionPk = IFNULL(p_externalPkId, expSessionPk),
         externalId = IFNULL(unhex(p_externalPkUUID), externalId)
       WHERE sessionId = row_session_id;
       SET p_id := row_session_id;

--- a/schemas/ispyb/stored_programs/sp_upsert_session_for_proposal_code_number.sql
+++ b/schemas/ispyb/stored_programs/sp_upsert_session_for_proposal_code_number.sql
@@ -1,3 +1,7 @@
+-- To test:
+-- SET @id := NULL;
+-- CALL upsert_session_for_proposal_code_number(@id, 'cm', 14451, 1, NULL, '2024-01-09 09:00:00', '2024-01-09 17:00:00', 'i04', 'Karl', NULL, NULL, NULL, 'Karl was here', NULL);
+
 DELIMITER ;;
 CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_session_for_proposal_code_number`(
 	 INOUT p_id int(11) unsigned,
@@ -8,13 +12,11 @@ CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_session_for_proposa
 	 p_startDate datetime,
 	 p_endDate datetime,
 	 p_beamlineName varchar(45),
-	 p_title varchar(255),
 	 p_beamlineOperator varchar(45),
 	 p_nbShifts int(10) unsigned,
 	 p_scheduled tinyint(1),
 	 p_usedFlag tinyint(1),
 	 p_comments varchar(255),
-	 p_externalPkId int(11) unsigned,
 	 p_externalPkUUID varchar(32)
  )
 	 MODIFIES SQL DATA
@@ -22,16 +24,16 @@ CREATE OR REPLACE DEFINER=`ispyb_root`@`%` PROCEDURE `upsert_session_for_proposa
 BEGIN
   DECLARE row_proposal_id int(10) unsigned DEFAULT NULL;
   DECLARE row_session_id int(10) unsigned DEFAULT NULL;
-  
+
   IF p_id IS NOT NULL OR (p_proposalCode IS NOT NULL AND p_proposalNumber IS NOT NULL) THEN
-    
+
     IF p_proposalCode IS NOT NULL AND p_proposalNumber IS NOT NULL THEN
       SELECT min(proposalId) INTO row_proposal_id FROM Proposal WHERE proposalCode=p_proposalCode AND proposalNumber=p_proposalNumber;
       IF row_proposal_id IS NULL THEN
         SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO=1644, MESSAGE_TEXT='Proposal given by p_proposalCode + p_proposalNumber does not exist.';
       END IF;
     END IF;
-    
+
     IF p_id IS NULL AND row_proposal_id IS NOT NULL THEN
       SELECT sessionId INTO row_session_id FROM BLSession WHERE proposalId = row_proposal_id AND visit_number = p_visitNumber;
     ELSEIF p_id IS NOT NULL THEN
@@ -40,9 +42,9 @@ BEGIN
 
     IF row_session_id IS NULL THEN
       INSERT INTO BLSession(sessionId, proposalId, visit_number, beamLineSetupId, startDate, endDate,
-        beamLineName, sessionTitle, beamLineOperator, nbShifts, scheduled, usedFlag, comments, expSessionPk, externalId)
+        beamLineName, beamLineOperator, nbShifts, scheduled, usedFlag, comments, externalId)
         VALUES (p_id, row_proposal_id, p_visitNumber, p_beamLineSetupId, p_startDate, p_endDate,
-          p_beamlineName, p_title, p_beamlineOperator, p_nbShifts, p_scheduled, p_usedFlag, p_comments, p_externalPkId, unhex(p_externalPkUUID));
+          p_beamlineName, p_beamlineOperator, p_nbShifts, p_scheduled, p_usedFlag, p_comments, unhex(p_externalPkUUID));
       SET p_id = LAST_INSERT_ID();
 
     ELSE
@@ -55,13 +57,11 @@ BEGIN
         startDate = IFNULL(p_startDate, startDate),
         endDate = IFNULL(p_endDate, endDate),
         beamLineName = IFNULL(p_beamlineName, beamLineName),
-        sessionTitle = IFNULL(p_title, sessionTitle),
         beamLineOperator = IFNULL(p_beamlineOperator, beamLineOperator),
         nbShifts = IFNULL(p_nbShifts, nbShifts),
         scheduled = IFNULL(p_scheduled, scheduled),
         usedFlag = IFNULL(p_usedFlag, usedFlag),
         comments = IFNULL(p_comments, comments),
-        expSessionPk = IFNULL(p_externalPkId, expSessionPk),
         externalId = IFNULL(unhex(p_externalPkUUID), externalId)
       WHERE sessionId = row_session_id;
       SET p_id := row_session_id;


### PR DESCRIPTION
Modify stored procedure ``upsert_session_for_proposal_code_number`` to remove references in queries to previously removed ``BLSession`` columns.