### PR TITLE
Replace FK index on BLSubSample with compound index

### DIFF
--- a/schemas/ispyb/updates/2024_03_05_BLSubSample_replace_index.sql
+++ b/schemas/ispyb/updates/2024_03_05_BLSubSample_replace_index.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_03_05_BLSubSample_replace_index.sql', 'ONGOING');
+
+CREATE INDEX IF NOT EXISTS BLSubSample_blSampleId_source ON BLSubSample(blSampleId, source);
+DROP INDEX IF EXISTS BLSubSample_FKIndex1 ON BLSubSample;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2024_03_05_BLSubSample_replace_index.sql';


### PR DESCRIPTION
Replace the `BLSubSample` index on `blSampleId` with a compound index `(blSampleId, source)`.

Queries that depended on the old index should be able to use the new index.

The new index helps to optimise at least one of our SynchWeb queries.  