### PR TITLE
[DSRV-899] Add processingPipelineId column to AutoProcProgram

### DIFF
--- a/schemas/ispyb/updates/2024_09_25_AutoProcProgram_processingPipelineId.sql
+++ b/schemas/ispyb/updates/2024_09_25_AutoProcProgram_processingPipelineId.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_09_25_AutoProcProgram_processingPipelineId.sql', 'ONGOING');
+
+ALTER TABLE AutoProcProgram ADD processingPipelineId int(11) unsigned DEFAULT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2024_09_25_AutoProcProgram_processingPipelineId.sql';


### PR DESCRIPTION
Ticket: https://jira.diamond.ac.uk/browse/DSRV-899

Since setting a constraint would require a rebuild, I've opted to create a basic, unsigned integer column. I've not deprecated the `processingPrograms` column yet, but this might be an interesting thing to add in the future.