### PR TITLE
Fix wrong scriptName in insert to SchemaStatus

### DIFF
--- a/schemas/ispyb/updates/2024_09_04_ProcessedTomogram_comment.sql
+++ b/schemas/ispyb/updates/2024_09_04_ProcessedTomogram_comment.sql
@@ -1,4 +1,4 @@
-INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_09_04_ProcessedTomogram_comment', 'ONGOING');
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_09_04_ProcessedTomogram_comment.sql', 'ONGOING');
 
 ALTER TABLE ProcessedTomogram COMMENT = 'Indicates the sample''s location on a multi-sample pin, where 1 is closest to the pin base or a sample''s position in a cryo-EM cassette';
 

--- a/schemas/ispyb/updates/2024_09_17_SpaceGroup_trim.sql
+++ b/schemas/ispyb/updates/2024_09_17_SpaceGroup_trim.sql
@@ -1,4 +1,4 @@
-INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_09_17_SpaceGroup_trim', 'ONGOING');
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_09_17_SpaceGroup_trim.sql', 'ONGOING');
 
 UPDATE SpaceGroup SET spaceGroupShortName=trim(trailing '1' FROM spaceGroupShortName) WHERE spaceGroupId in (51,52,53,54,55,56,57,58,59,60,61,62,63,64,73,74,127,128,129,130,205,206,223,224,227,228,230);
 


### PR DESCRIPTION
Two update .sql scripts were inserting incorrect scriptName values:

- `2024_09_04_ProcessedTomogram_comment.sql`
- `2024_09_17_SpaceGroup_trim.sql` 