### PR TITLE
Add gridSquareId foreign key in Tomogram table

### DIFF
--- a/schemas/ispyb/updates/2025_01_08_ParticleClassificationGroup_binnedPixelSize.sql
+++ b/schemas/ispyb/updates/2025_01_08_ParticleClassificationGroup_binnedPixelSize.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_01_08_ParticleClassificationGroup_binnedPixelSize.sql', 'ONGOING');
+
+ALTER TABLE ParticleClassificationGroup ADD binnedPixelSize float COMMENT 'Binned pixel size. Unit: Angstroms', ALGORITHM=INSTANT;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_01_08_ParticleClassificationGroup_binnedPixelSize.sql';

--- a/schemas/ispyb/updates/2025_01_24_Tomogram_gridSquare.sql
+++ b/schemas/ispyb/updates/2025_01_24_Tomogram_gridSquare.sql
@@ -1,0 +1,9 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_01_24_Tomogram_gridSquare.sql', 'ONGOING');
+
+ALTER TABLE Tomogram
+  ADD gridSquareId int(11) unsigned COMMENT 'FK, references medium mag map in GridSquare', 
+  ADD CONSTRAINT `Tomogram_fk_gridSquareId`
+    FOREIGN KEY (`gridSquareId`)
+      REFERENCES `GridSquare` (`gridSquareId`);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_01_24_Tomogram_gridSquare.sql';


### PR DESCRIPTION
In order to store medium mag maps, the Tomogram table needs to link back to GridSquare, which has a compatible structure. This is useful for displaying data in an Atlas-like way for tomograms.