### PR TITLE
Add reference to BLSample, describe position type

### DIFF
--- a/schemas/ispyb/updates/2025_04_11_Position_blSampleId_positionType.sql
+++ b/schemas/ispyb/updates/2025_04_11_Position_blSampleId_positionType.sql
@@ -1,0 +1,10 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_04_11_Position_blSampleId_positionType.sql', 'ONGOING');
+
+ALTER TABLE Position
+  ADD positionType varchar(45) COMMENT 'Action (type) that originated this position',
+  ADD blSampleId int(11) unsigned COMMENT 'FK, references parent sample',
+  ADD CONSTRAINT `Position_fk_blSampleId`
+    FOREIGN KEY (`blSampleId`)
+      REFERENCES `BLSample` (`blSampleId`);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_04_11_Position_blSampleId_positionType.sql';


### PR DESCRIPTION
This adds two new columns to `Position`, as it is possible that we'll have multiple methods of inserting new dispensing locations (auto - through CHIMP-CHOMP and manual - through SynchWeb).

This establishes a one-to-many relationship between samples and positions.