### PR TITLE
Recreate FK constraints referencing LabContact(labContactId) 

### DIFF
--- a/schemas/ispyb/updates/2025_04_16_labContacts_fk_on_delete_set_null.sql
+++ b/schemas/ispyb/updates/2025_04_16_labContacts_fk_on_delete_set_null.sql
@@ -1,0 +1,26 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_04_16_labContacts_fk_on_delete_set_null.sql', 'ONGOING');
+
+ALTER TABLE Shipping
+  DROP CONSTRAINT Shipping_ibfk_2,
+  DROP CONSTRAINT Shipping_ibfk_3;
+
+ALTER TABLE Shipping
+  ADD CONSTRAINT Shipping_ibfk_2
+    FOREIGN KEY (sendingLabContactId)
+      REFERENCES LabContact (labContactId)
+        ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT Shipping_ibfk_3
+    FOREIGN KEY (returnLabContactId)
+      REFERENCES LabContact (labContactId)
+        ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE DewarRegistry_has_Proposal
+  DROP CONSTRAINT DewarRegistry_has_Proposal_ibfk4;
+
+ALTER TABLE DewarRegistry_has_Proposal
+  ADD CONSTRAINT DewarRegistry_has_Proposal_ibfk4
+    FOREIGN KEY (labContactId)
+      REFERENCES LabContact (labContactId)
+        ON DELETE SET NULL ON UPDATE CASCADE;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_04_16_labContacts_fk_on_delete_set_null.sql';


### PR DESCRIPTION
Some of the foreign key constraints referencing LabContact(labContactId) are currently defined as `ON DELETE CASCADE` which is a problem when we need to delete old lab contacts due to GDPR. 

This PR will re-create these foreign key constraints with `ON DELETE SET NULL` instead.