### PR TITLE
Rename position ID column

### DIFF
--- a/schemas/ispyb/updates/2025_05_02_BLSamplePosition_rename_column.sql
+++ b/schemas/ispyb/updates/2025_05_02_BLSamplePosition_rename_column.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_05_02_BLSamplePosition_rename_column.sql', 'ONGOING');
+
+ALTER TABLE BLSamplePosition
+    RENAME COLUMN `positionId` TO `blSamplePositionId`;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_05_02_BLSamplePosition_rename_column.sql';


### PR DESCRIPTION
To maintain consistency across primary key ID columns in tables, the `positionId` column has been renamed to `blSamplePositionId`