### PR TITLE
Update maximum string length for p_status

### DIFF
--- a/schemas/ispyb/stored_programs/sp_retrieve_containers_on_beamline_with_status.sql
+++ b/schemas/ispyb/stored_programs/sp_retrieve_containers_on_beamline_with_status.sql
@@ -1,5 +1,5 @@
 DELIMITER ;;
-CREATE DEFINER=`ispyb_root`@`%` PROCEDURE `retrieve_containers_on_beamline_with_status`(IN p_beamline varchar(20), IN p_status varchar(40))
+CREATE DEFINER=`ispyb_root`@`%` PROCEDURE `retrieve_containers_on_beamline_with_status`(IN p_beamline varchar(20), IN p_status varchar(45))
     READS SQL DATA
     COMMENT 'Returns a multi-row result-set with info about when containers on beamline p_beamline last had status p_status'
 BEGIN


### PR DESCRIPTION
In the database, the maximum length for `containerStatus` on `Container` and `status` on `ContainerHistory` is 45. However, in this stored procedure, the maximum allowed length is 40, which makes some rows "unselectable".

This makes it so that the maximum string length is in line with the table definitions.