### PR TITLE
DSRV-1249: Add new column Container.parentContainerLocation

### DIFF
--- a/schemas/ispyb/updates/2025_07_25_Container_parentContainerLocation.sql
+++ b/schemas/ispyb/updates/2025_07_25_Container_parentContainerLocation.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2025_07_25_Container_parentContainerLocation.sql', 'ONGOING');
+
+ALTER TABLE Container
+  ADD parentContainerLocation int unsigned
+    COMMENT 'Indicates where inside the parent container this container is located', ALGORITHM=INSTANT;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2025_07_25_Container_parentContainerLocation.sql';


### PR DESCRIPTION
This adds a new column parentContainerLocation in the Container table. 

Is the column comment descriptive enough? Is the int enough for people to understand where that is inside the parent container? What does e.g. 0 or 1 mean? 

Edited to add: Yes, we think this is sufficiently descriptive. The positions should be labelled on the parent container.