### PR TITLE
Add foreign key to autoProcProgramId in AutoProc

### DIFF
--- a/schemas/ispyb/updates/2026_04_24_AutoProc_autoProcProgramId.sql
+++ b/schemas/ispyb/updates/2026_04_24_AutoProc_autoProcProgramId.sql
@@ -1,0 +1,8 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2026_04_24_AutoProc_autoProcProgramId.sql', 'ONGOING');
+
+ALTER TABLE AutoProc
+ADD CONSTRAINT AutoProc_fk_autoProcProgramId
+FOREIGN KEY (autoProcProgramId)
+    REFERENCES AutoProc (autoProcProgramId);
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2026_04_24_AutoProc_autoProcProgramId.sql';


### PR DESCRIPTION
Because `autoProcProgramId` is not a foreign key, SQLAlchemy generated models fail to build relationships, and the right checks aren't performed when inserting. This turns `autoProcProgramId` into a FK.